### PR TITLE
Add editor tab to upgrade release values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,19 @@
 SHELL = /bin/bash
 
+PLUGIN_NAME=octant-helm
+
+ifdef XDG_CONFIG_HOME
+	OCTANT_PLUGIN_DIR ?= ${XDG_CONFIG_HOME}/octant/plugins
+else ifeq ($(OS),Windows_NT)
+	OCTANT_PLUGIN_DIR ?= ${LOCALAPPDATA}/octant/plugins
+else
+	OCTANT_PLUGIN_DIR ?= ${HOME}/.config/octant/plugins
+endif
+
 .PHONY: build
 build:
-	go build -o bin/octant-helm cmd/octant-helm/main.go
+	@go build -o bin/$(PLUGIN_NAME) cmd/octant-helm/main.go
+	@cp bin/$(PLUGIN_NAME) $(OCTANT_PLUGIN_DIR)/$(PLUGIN_NAME)
 
 .PHONY: dev
 dev:

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	helm.sh/helm/v3 v3.4.2
 	k8s.io/api v0.19.4
 	k8s.io/apimachinery v0.19.4
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/pkg/plugin/actions/actions.go
+++ b/pkg/plugin/actions/actions.go
@@ -3,12 +3,17 @@ package actions
 import (
 	"fmt"
 	"github.com/bloodorangeio/octant-helm/pkg/config"
+	"github.com/bloodorangeio/octant-helm/pkg/helm"
 	"github.com/vmware-tanzu/octant/pkg/action"
 	"github.com/vmware-tanzu/octant/pkg/plugin/service"
+	"github.com/vmware-tanzu/octant/pkg/store"
 	helmAction "helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chartutil"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 const (
+	UpdateHelmReleaseValues = "octant-helm.dev/update"
 	UninstallHelmReleaseAction = "octant-helm.dev/uninstall"
 )
 
@@ -30,6 +35,16 @@ func ActionHandler(request *service.ActionRequest) error {
 			return err
 		}
 		return uninstallRelease(request, actionConfig, releaseName)
+	case UpdateHelmReleaseValues:
+		releaseValues, err := request.Payload.String("update")
+		if err != nil {
+			return err
+		}
+		releaseName, err := request.Payload.String("releaseName")
+		if err != nil {
+			return err
+		}
+		return updateReleaseValues(request, actionConfig, releaseValues, releaseName)
 	default:
 		return fmt.Errorf("unable to find handler for plugin: %s", "octant-helm")
 	}
@@ -44,5 +59,40 @@ func uninstallRelease(request *service.ActionRequest, config *helmAction.Configu
 
 	alert := action.CreateAlert(action.AlertTypeInfo, "Uninstalled helm release: "+release.Release.Name, action.DefaultAlertExpiration)
 	request.DashboardClient.SendAlert(request.Context(), request.ClientState.ClientID, alert)
+	return nil
+}
+
+func updateReleaseValues(request *service.ActionRequest, config *helmAction.Configuration, values string, releaseName string) error {
+	upgradeClient := helmAction.NewUpgrade(config)
+
+	client := request.DashboardClient
+	ul, err := client.List(request.Context(), store.Key{
+		APIVersion: "v1",
+		Kind:       "Secret",
+		Selector: &labels.Set{
+			"owner": "helm",
+			"name":  releaseName,
+		},
+	})
+	if err != nil {
+		return err
+	}
+	r := helm.UnstructuredListToHelmReleaseByName(ul, releaseName)
+	if r == nil {
+		return fmt.Errorf("cannot find release name: %s", releaseName)
+	}
+	v, err := chartutil.ReadValues([]byte(values))
+	if err != nil {
+		return err
+	}
+	// TODO: There are upgrades which require secrets. How would this be shown to a user?
+	release, err := upgradeClient.Run(releaseName, r.Chart, v)
+	if err != nil {
+		message := fmt.Sprintf("Unable to upgrade release: %s", err)
+		request.DashboardClient.SendAlert(request.Context(), request.ClientState.ClientID, action.CreateAlert(action.AlertTypeError, message, action.DefaultAlertExpiration))
+	} else {
+		alert := action.CreateAlert(action.AlertTypeInfo, "Upgrade helm release: "+release.Name, action.DefaultAlertExpiration)
+		request.DashboardClient.SendAlert(request.Context(), request.ClientState.ClientID, alert)
+	}
 	return nil
 }

--- a/pkg/plugin/router/handlers.go
+++ b/pkg/plugin/router/handlers.go
@@ -38,7 +38,12 @@ func helmReleaseHandler(request service.Request) (component.ContentResponse, err
 	if err != nil {
 		return component.EmptyContentResponse, err
 	}
+	helmEditorView, err := views.BuildHelmReleaseViewForValues(request)
+	if err != nil {
+		return component.EmptyContentResponse, err
+	}
+
 	response := component.NewContentResponse(title)
-	response.Add(helmReleaseView)
+	response.Add(helmReleaseView, helmEditorView)
 	return *response, nil
 }

--- a/pkg/plugin/settings/capabilities.go
+++ b/pkg/plugin/settings/capabilities.go
@@ -25,6 +25,7 @@ func GetCapabilities() *plugin.Capabilities {
 	return &plugin.Capabilities{
 		ActionNames: []string{
 			actions.UninstallHelmReleaseAction,
+			actions.UpdateHelmReleaseValues,
 		},
 		IsModule: true,
 	}


### PR DESCRIPTION
Shows an editor tab with default chart values if no user supplied values otherwise show current applied values.

![image](https://user-images.githubusercontent.com/10288252/116015968-0cc67980-a5f0-11eb-8445-9f7c073b63e3.png)

Signed-off-by: Sam Foo <foos@vmware.com>